### PR TITLE
security: make RSA optional to mitigate RUSTSEC-2023-0071

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-01-22
+
+### Security
+
+- **RSA now optional:** Removed RSA from default features due to RUSTSEC-2023-0071 (Marvin Attack timing vulnerability in the `rsa` crate). Users who don't need RSA are no longer affected by this upstream vulnerability.
+
+### Changed
+
+- `arcanum-asymmetric`: RSA feature is now opt-in (`features = ["rsa"]`)
+- Default features for `arcanum-asymmetric` are now: `ecies`, `x25519`, `x448`
+
 ## [0.1.0] - 2025-01-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Daemoniorum-LLC/arcanum"
@@ -41,21 +41,21 @@ categories = ["cryptography", "no-std"]
 # ═══════════════════════════════════════════════════════════════════════════════
 # INTERNAL CRATES
 # ═══════════════════════════════════════════════════════════════════════════════
-arcanum-core = { version = "0.1.0", path = "crates/arcanum-core" }
-arcanum-primitives = { version = "0.1.0", path = "crates/arcanum-primitives" }
-arcanum-symmetric = { version = "0.1.0", path = "crates/arcanum-symmetric" }
-arcanum-asymmetric = { version = "0.1.0", path = "crates/arcanum-asymmetric" }
-arcanum-signatures = { version = "0.1.0", path = "crates/arcanum-signatures" }
-arcanum-hash = { version = "0.1.0", path = "crates/arcanum-hash" }
-arcanum-pqc = { version = "0.1.0", path = "crates/arcanum-pqc" }
-arcanum-zkp = { version = "0.1.0", path = "crates/arcanum-zkp" }
-arcanum-threshold = { version = "0.1.0", path = "crates/arcanum-threshold" }
-arcanum-verify = { version = "0.1.0", path = "crates/arcanum-verify" }
-arcanum-agile = { version = "0.1.0", path = "crates/arcanum-agile" }
-arcanum-holocrypt = { version = "0.1.0", path = "crates/arcanum-holocrypt" }
-arcanum-keystore = { version = "0.1.0", path = "crates/arcanum-keystore" }
-arcanum-protocols = { version = "0.1.0", path = "crates/arcanum-protocols" }
-arcanum-formats = { version = "0.1.0", path = "crates/arcanum-formats" }
+arcanum-core = { version = "0.1.1", path = "crates/arcanum-core" }
+arcanum-primitives = { version = "0.1.1", path = "crates/arcanum-primitives" }
+arcanum-symmetric = { version = "0.1.1", path = "crates/arcanum-symmetric" }
+arcanum-asymmetric = { version = "0.1.1", path = "crates/arcanum-asymmetric" }
+arcanum-signatures = { version = "0.1.1", path = "crates/arcanum-signatures" }
+arcanum-hash = { version = "0.1.1", path = "crates/arcanum-hash" }
+arcanum-pqc = { version = "0.1.1", path = "crates/arcanum-pqc" }
+arcanum-zkp = { version = "0.1.1", path = "crates/arcanum-zkp" }
+arcanum-threshold = { version = "0.1.1", path = "crates/arcanum-threshold" }
+arcanum-verify = { version = "0.1.1", path = "crates/arcanum-verify" }
+arcanum-agile = { version = "0.1.1", path = "crates/arcanum-agile" }
+arcanum-holocrypt = { version = "0.1.1", path = "crates/arcanum-holocrypt" }
+arcanum-keystore = { version = "0.1.1", path = "crates/arcanum-keystore" }
+arcanum-protocols = { version = "0.1.1", path = "crates/arcanum-protocols" }
+arcanum-formats = { version = "0.1.1", path = "crates/arcanum-formats" }
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SYMMETRIC CRYPTOGRAPHY

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -109,6 +109,7 @@ Please include the following in your report:
 
 - **Side-channel attacks:** Timing attacks are mitigated through constant-time implementations, but physical side-channel attacks (power analysis, EM) are not addressed
 - **Post-quantum algorithms:** ML-KEM and ML-DSA are based on NIST standardized algorithms but are relatively new
+- **RSA (RUSTSEC-2023-0071):** The optional RSA feature uses the `rsa` crate which has a known timing vulnerability (Marvin Attack). As of v0.1.1, RSA is **not included in default features**. Users who don't need RSA are not affected. If you require RSA, understand the risks or wait for an upstream fix.
 
 ### Moloch
 

--- a/crates/arcanum-asymmetric/Cargo.toml
+++ b/crates/arcanum-asymmetric/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography"]
 [dependencies]
 arcanum-core = { version = "0.1.0", path = "../arcanum-core" }
 
-# RSA
-rsa = { version = "0.9", features = ["sha2", "hazmat"] }
+# RSA (optional - has known timing vulnerability RUSTSEC-2023-0071)
+rsa = { version = "0.9", optional = true, features = ["sha2", "hazmat"] }
 
 # Elliptic curves
 elliptic-curve = { version = "0.13", features = ["sec1", "pkcs8", "ecdh"] }
@@ -52,8 +52,8 @@ criterion = "0.5"
 proptest = "1.5"
 
 [features]
-default = ["rsa", "ecies", "x25519", "x448"]
-rsa = []
+default = ["ecies", "x25519", "x448"]  # RSA excluded from default due to RUSTSEC-2023-0071
+rsa = ["dep:rsa"]
 ecies = []
 x25519 = []
 x448 = []

--- a/crates/arcanum-asymmetric/benches/asymmetric_bench.rs
+++ b/crates/arcanum-asymmetric/benches/asymmetric_bench.rs
@@ -7,8 +7,10 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 
 use arcanum_asymmetric::{
-    P256SecretKey, P384SecretKey, RsaPrivateKey, X25519PublicKey, X25519SecretKey, x25519::X25519,
+    P256SecretKey, P384SecretKey, X25519PublicKey, X25519SecretKey, x25519::X25519,
 };
+#[cfg(feature = "rsa")]
+use arcanum_asymmetric::RsaPrivateKey;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // X25519 BENCHMARKS
@@ -83,6 +85,7 @@ fn bench_x25519_triple_dh(c: &mut Criterion) {
 // RSA BENCHMARKS
 // ═══════════════════════════════════════════════════════════════════════════════
 
+#[cfg(feature = "rsa")]
 fn bench_rsa_keygen(c: &mut Criterion) {
     let mut group = c.benchmark_group("rsa_keygen");
     group.sample_size(10); // RSA keygen is slow
@@ -96,6 +99,7 @@ fn bench_rsa_keygen(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(feature = "rsa")]
 fn bench_rsa_encrypt_decrypt(c: &mut Criterion) {
     let mut group = c.benchmark_group("rsa_encrypt_decrypt");
 
@@ -167,6 +171,7 @@ fn bench_rsa_encrypt_decrypt(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(feature = "rsa")]
 fn bench_rsa_sign_verify(c: &mut Criterion) {
     let mut group = c.benchmark_group("rsa_sign_verify");
 
@@ -325,7 +330,13 @@ fn bench_serialization(c: &mut Criterion) {
         b.iter(|| black_box(X25519PublicKey::from_hex(&hex_str).unwrap()));
     });
 
-    // RSA serialization
+    group.finish();
+}
+
+#[cfg(feature = "rsa")]
+fn bench_rsa_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rsa_serialization");
+
     let rsa_private = RsaPrivateKey::generate(2048).unwrap();
     let rsa_der = rsa_private.to_pkcs8_der().unwrap();
 
@@ -340,6 +351,7 @@ fn bench_serialization(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(feature = "rsa")]
 criterion_group!(
     benches,
     bench_x25519_keygen,
@@ -352,5 +364,19 @@ criterion_group!(
     bench_ecdh_dh,
     bench_key_exchange_comparison,
     bench_serialization,
+    bench_rsa_serialization,
 );
+
+#[cfg(not(feature = "rsa"))]
+criterion_group!(
+    benches,
+    bench_x25519_keygen,
+    bench_x25519_dh,
+    bench_x25519_triple_dh,
+    bench_ecdh_keygen,
+    bench_ecdh_dh,
+    bench_key_exchange_comparison,
+    bench_serialization,
+);
+
 criterion_main!(benches);

--- a/crates/arcanum-asymmetric/benches/asymmetric_bench.rs
+++ b/crates/arcanum-asymmetric/benches/asymmetric_bench.rs
@@ -4,7 +4,9 @@
 
 #![allow(clippy::unit_arg)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+#[cfg(feature = "rsa")]
+use criterion::{BenchmarkId, Throughput};
 
 use arcanum_asymmetric::{
     P256SecretKey, P384SecretKey, X25519PublicKey, X25519SecretKey, x25519::X25519,

--- a/crates/arcanum-asymmetric/benches/asymmetric_bench.rs
+++ b/crates/arcanum-asymmetric/benches/asymmetric_bench.rs
@@ -4,15 +4,15 @@
 
 #![allow(clippy::unit_arg)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
 #[cfg(feature = "rsa")]
 use criterion::{BenchmarkId, Throughput};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 
+#[cfg(feature = "rsa")]
+use arcanum_asymmetric::RsaPrivateKey;
 use arcanum_asymmetric::{
     P256SecretKey, P384SecretKey, X25519PublicKey, X25519SecretKey, x25519::X25519,
 };
-#[cfg(feature = "rsa")]
-use arcanum_asymmetric::RsaPrivateKey;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // X25519 BENCHMARKS


### PR DESCRIPTION
## Summary

- Make RSA an opt-in feature due to known timing vulnerability (Marvin Attack)
- Users who don't need RSA are no longer affected by RUSTSEC-2023-0071
- Version bumped to 0.1.1

## Changes

- `arcanum-asymmetric`: RSA dependency now optional (`features = ["rsa"]`)
- Default features: `[ecies, x25519, x448]` (RSA removed)
- Updated SECURITY.md to document the vulnerability
- Added CHANGELOG entry

## Security Advisory

The `rsa` crate (v0.9.10) has a known timing vulnerability:
- **ID:** RUSTSEC-2023-0071
- **Title:** Marvin Attack: potential key recovery through timing sidechannels
- **Severity:** 5.9 (medium)
- **Status:** No upstream fix available

By making RSA optional and removing it from defaults, users who don't explicitly need RSA support are protected.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` passes
- [x] `cargo tree -i rsa` shows RSA not included in default build
- [x] RSA can still be enabled with `features = ["rsa"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)